### PR TITLE
Composer 2 do not allow uppercase characters in package name:

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -341,7 +341,7 @@
         {
             "type": "package",
             "package": {
-                "name": "smillart/WAI-ARIA-Patterns-And-Widgets",
+                "name": "smillart/wai-aria-patterns-and-widgets",
                 "version": "1.0.6",
                 "type": "theme-library",
                 "require": {


### PR DESCRIPTION
Openfed composer.json require smillart/wai-aria-patterns-and-widgets that do not match Openfed-libraries name.

If you do a composer require smillart/WAI-ARIA-Patterns-And-Widgets composer will return:
```smillart/WAI-ARIA-Patterns-And-Widgets is invalid, it should not contain uppercase characters```

I think putting everything in lowercase will solve the issue in this case