### PR TITLE
Composer 2 do not allow uppercase characters in package name:

### DIFF
--- a/include/all$f249c1e0ce8518b48cf83f0fa05fd03fade25f71.json
+++ b/include/all$f249c1e0ce8518b48cf83f0fa05fd03fade25f71.json
@@ -302,7 +302,7 @@
         },
         "smillart/wai-aria-patterns-and-widgets": {
             "1.0.6": {
-                "name": "smillart/WAI-ARIA-Patterns-And-Widgets",
+                "name": "smillart/wai-aria-patterns-and-widgets",
                 "version": "1.0.6",
                 "version_normalized": "1.0.6.0",
                 "dist": {

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
             <a href="https://openfed.github.io/openfed-libraries">
                 <h1>openfed/openfed-libraries</h1>
             </a>
-            <span class="badge badge-light m-1" title="Tuesday, 01-Feb-2022 15:56:22 CET">
-                Last updated: <br class="d-md-none"> <time datetime="2022-02-01T15:56:22+01:00">Tuesday, 01 Feb 2022 15:56:22 CET</time>
+            <span class="badge badge-light m-1" title="Tuesday, 26-Apr-2022 09:27:03 UTC">
+                Last updated: <br class="d-md-none"> <time datetime="2022-04-26T09:27:03+00:00">Tuesday, 26 Apr 2022 09:27:03 UTC</time>
             </span>
         </div>
 

--- a/p2/smillart/wai-aria-patterns-and-widgets.json
+++ b/p2/smillart/wai-aria-patterns-and-widgets.json
@@ -2,7 +2,7 @@
     "packages": {
         "smillart/wai-aria-patterns-and-widgets": [
             {
-                "name": "smillart/WAI-ARIA-Patterns-And-Widgets",
+                "name": "smillart/wai-aria-patterns-and-widgets",
                 "version": "1.0.6",
                 "version_normalized": "1.0.6.0",
                 "dist": {

--- a/packages.json
+++ b/packages.json
@@ -1,8 +1,8 @@
 {
     "packages": [],
     "includes": {
-        "include/all$d9ef18e65157b1cc90008d9deb7b237d0546374f.json": {
-            "sha1": "d9ef18e65157b1cc90008d9deb7b237d0546374f"
+        "include/all$f249c1e0ce8518b48cf83f0fa05fd03fade25f71.json": {
+            "sha1": "f249c1e0ce8518b48cf83f0fa05fd03fade25f71"
         }
     },
     "metadata-url": "/openfed-libraries/p2/%package%.json",


### PR DESCRIPTION
Pull request for files generated by the make on the gh-pages branch.

See https://github.com/openfed/openfed-libraries/pull/1